### PR TITLE
Don't create directories unless an artifact can be found

### DIFF
--- a/src/main/java/org/vaadin/JavadocBrowser.java
+++ b/src/main/java/org/vaadin/JavadocBrowser.java
@@ -141,8 +141,6 @@ public class JavadocBrowser extends HttpServlet {
             File cachefile) throws FileNotFoundException {
         String artifactName = artifactId + "-" + version;
         if (!cachefile.exists()) {
-            cachefile.getParentFile().mkdirs();
-
             for (String repo : repos) {
                 String repopath = "/" + groupId.replace(".", "/") + "/"
                         + artifactId + "/" + version + "/";
@@ -150,6 +148,7 @@ public class JavadocBrowser extends HttpServlet {
                     URL url = new URL(repo + repopath + artifactName
                             + "-javadoc.jar");
                     InputStream openStream = url.openStream();
+                    cachefile.getParentFile().mkdirs();
                     IOUtils.copy(openStream, new FileOutputStream(cachefile));
                     openStream.close();
                     break;


### PR DESCRIPTION
Fixed the issue where the cache method would still create
directories for holding cached versions of the javadoc artifacts
even though no artifacts could be found. E.g. specifying version
2.foobar created the directory, which caused the listings to point
to non-existing javadoc. Following the link always produced "Oops".
